### PR TITLE
Add Travis and AppVeyor to build multi-arch image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ script:
       chmod +x manifest-tool
 
       # Push manifest-list
-      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:OS-ARCH" --target "mplatform/mquery:$TRAVIS_TAG"
-      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:OS-ARCH" --target "mplatform/mquery:latest"
+      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:${TRAVIS_TAG}-OS-ARCH" --target "mplatform/mquery:$TRAVIS_TAG"
+      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:${TRAVIS_TAG}-OS-ARCH" --target "mplatform/mquery:latest"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+sudo: required
+
+services:
+ - docker
+
+script:
+  - go get github.com/dghubble/sling
+  - make cross
+  - make static
+  - cp mquery mquery-linux-amd64
+
+  # Update docker for multi-stage build
+  - sudo service docker stop
+  - curl -fsSL https://get.docker.com/ | sudo sh
+
+  # Build all images
+  - docker build --build-arg PLATFORM=linux-amd64 -t mplatform/mquery:linux-amd64 -f packaging/Dockerfile.linux .
+  - docker build --build-arg PLATFORM=linux-arm -t mplatform/mquery:linux-arm -f packaging/Dockerfile.linux .
+  - docker build --build-arg PLATFORM=linux-arm64 -t mplatform/mquery:linux-arm64 -f packaging/Dockerfile.linux .
+  - docker build --build-arg PLATFORM=linux-ppc64le -t mplatform/mquery:linux-ppc64le -f packaging/Dockerfile.linux .
+  - docker build --build-arg PLATFORM=linux-s390x -t mplatform/mquery:linux-s390x -f packaging/Dockerfile.linux .
+
+  # Test at least Intel image
+  - docker run mplatform/mquery:linux-amd64 golang
+
+  - >
+    if [ -n "$TRAVIS_TAG" ]; then
+      # Push all images
+      travis_retry timeout 5m docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
+
+      docker tag mplatform/mquery:linux-amd64 mplatform/mquery:${TRAVIS_TAG}-linux-amd64
+      docker tag mplatform/mquery:linux-arm mplatform/mquery:${TRAVIS_TAG}-linux-arm
+      docker tag mplatform/mquery:linux-arm64 mplatform/mquery:${TRAVIS_TAG}-linux-arm64
+      docker tag mplatform/mquery:linux-ppc64le mplatform/mquery:${TRAVIS_TAG}-linux-ppc64le
+      docker tag mplatform/mquery:linux-s390x mplatform/mquery:${TRAVIS_TAG}-linux-s390x
+
+      # push version for each platform
+      docker push mplatform/mquery:${TRAVIS_TAG}-linux-amd64
+      docker push mplatform/mquery:${TRAVIS_TAG}-linux-arm
+      docker push mplatform/mquery:${TRAVIS_TAG}-linux-arm64
+      docker push mplatform/mquery:${TRAVIS_TAG}-linux-ppc64le
+      docker push mplatform/mquery:${TRAVIS_TAG}-linux-s390x
+
+      # Download manifest-tool
+      wget https://github.com/estesp/manifest-tool/releases/download/v0.6.0/manifest-tool-linux-amd64
+      mv manifest-tool-linux-amd64 manifest-tool
+      chmod +x manifest-tool
+
+      # Push manifest-list
+      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:OS-ARCH" --target "mplatform/mquery:$TRAVIS_TAG"
+      ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/mquery:OS-ARCH" --target "mplatform/mquery:latest"
+    fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+build_script:
+  - go get github.com/dghubble/sling
+  - go build mquery.go
+  - docker build -t mplatform/mquery:windows-amd64 -f packaging/Dockerfile.windows .
+
+test_script:
+  - docker run mplatform/mquery:windows-amd64 golang
+
+deploy_script:
+  - ps: >-
+      if (Test-Path Env:\APPVEYOR_REPO_TAG_NAME) {
+
+        docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+
+        docker tag mplatform/mquery:windows-amd64 mplatform/mquery:$($env:APPVEYOR_REPO_TAG_NAME)-windows-amd64
+
+        docker push mplatform/mquery:$($env:APPVEYOR_REPO_TAG_NAME)-windows-amd64
+
+      }

--- a/packaging/Dockerfile.linux
+++ b/packaging/Dockerfile.linux
@@ -1,0 +1,7 @@
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+FROM scratch
+ARG PLATFORM=linux-amd64
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY mquery-${PLATFORM} /mquery
+ENTRYPOINT [ "/mquery" ]

--- a/packaging/Dockerfile.windows
+++ b/packaging/Dockerfile.windows
@@ -1,0 +1,3 @@
+FROM microsoft/nanoserver
+COPY mquery.exe mquery.exe
+ENTRYPOINT [ "mquery.exe" ]


### PR DESCRIPTION
Here is a CI pipeline to draft a multi-arch Docker image for mquery, so all people just can run it on their favorite Docker platform.

The Travis build builds static binaries for all Linux platforms.
Only if it is a tagged build (GitHub release), it also builds Docker images for them and pushes them to Docker Hub. We use a multi-stage build to have "FROM scratch" and only COPY deployment for the cross-platforms.
Afterwards Travis downloads the manifest-tool and drafts and pushes the manifest list for the specific version and a "latest" tag as well.

The AppVeyor build does the Windows build. Also only on a GitHub release it creates and pushes the Windows Docker image to Docker Hub.

Both Travis and AppVeyor need DOCKER_USER + DOCKER_PASS as environment variables configured through their web UI.
